### PR TITLE
Linter tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.DS_Store
 *.rdb
+package-lock.json

--- a/.textlintrc
+++ b/.textlintrc
@@ -16,6 +16,7 @@ rules:
   period-in-list-item: true
 
   rousseau:
+    severity: warning
     showLevels:
     - suggestion
     - warning

--- a/.textlintrc
+++ b/.textlintrc
@@ -50,3 +50,9 @@ rules:
 
   write-good:
     severity: warning
+
+
+filters:
+  allowlist:
+    allow:
+    - '/<i>.*<\/i>/g'    # idiomatic terms

--- a/.textlintrc
+++ b/.textlintrc
@@ -26,6 +26,10 @@ rules:
     - Html
     ignoreTypes:
     - passive            # covered by write-good
+    - lexical-illusion
+    - so
+    - adverbs
+    - weasel
     - sentence:uppercase # covered by en-capitalization
 
   spelling:

--- a/.textlintrc
+++ b/.textlintrc
@@ -43,4 +43,5 @@ rules:
     - ['place\W?tech(nology)?', 'Place Technology']
     - ['back\W?office', 'Backoffice']
 
-  write-good: true
+  write-good:
+    severity: warning

--- a/.textlintrc
+++ b/.textlintrc
@@ -37,7 +37,7 @@ rules:
     skipPatterns:
     - '/placeos/i'
     - '/backoffice/i'
-    - '/\b(?:[A-Z]){2,}\b/g' # acronyms
+    - '/[A-Z]{2,}/'      # acronyms
     - chatbot
     - webhook
 


### PR DESCRIPTION
Adjust linter config to:
- remove duplication between rules engines
- ignore text enclosed in [HTML idiomatic semantic elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i) (resolves #26)
- mark language style suggestion as neutral, rather than errors