### PR TITLE
ignore linting errors in self-referential links

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -56,3 +56,4 @@ filters:
   allowlist:
     allow:
     - '/<i>.*<\/i>/g'    # idiomatic terms
+    - '/\[(.*\W)?(\w+)(\W.{4,})?\]\(.*\2.*\)/i'  # link text in link


### PR DESCRIPTION
Prevent the proofreader from flagging errors when a link title refers to the terms contained in the link URL.

Fixes #30.