### PR TITLE
Move Category of Write A Driver

### DIFF
--- a/tutorial/write-a-driver.md
+++ b/tutorial/write-a-driver.md
@@ -1,5 +1,5 @@
 ---
-title: How To Write A Driver
+title: Writing A Driver
 description: Everything you need to know about writing drivers for PlaceOS
 ---
 


### PR DESCRIPTION
This was merged to `master` under *how-to* category, when it should be under *tutorial* category, as it is an introduction to the concept. 