### PR TITLE
docs(auth/saml): map login_name to objectidentifier not emailaddress

### DIFF
--- a/how-to/authentication/configure-saml.md
+++ b/how-to/authentication/configure-saml.md
@@ -37,7 +37,7 @@ Here is a description of each field:
     -  Request this URL when sending the metadata URL
     -  Azure AD URLs are often in the format: `https://login.microsoftonline.com/**tenant-ID**/saml2`
     -  OKTA URLs are often in the format: `https://**okta.domain.com**/app/**app-name**/**app-id-number**/sso/saml`
-    -  ADFS URLs are often in the format: `https://adfs.myorganistaion.com/adfs/ls`
+    -  AD FS URLs are often in the format: `https://adfs.myorganistaion.com/adfs/ls`
     -  Auth0 URLs are often in the format: `https://myorganisation.auth0.com/samlp/`
 - `Name Identifier Format`: the format of the response data
     -  Set to `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`
@@ -46,11 +46,11 @@ Here is a description of each field:
     -  Clients sometimes request you change these to match their system
     -  Example:
 
-  | Name | Name_format | Friendly_name |
+  | Name | `Name_format` | `Friendly_name` |
   | --- | --- | --- |
-  | email | urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified | Email Address |
-  | first_name | urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified | Given Name |
-  | last_name | urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified | Surname |
+  | `email` | `urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified` | Email Address |
+  | `first_name` | `urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified` | Given Name |
+  | `last_name` | `urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified` | Surname |
 
 - `Assertion URL (Reply URL / Callback URL)`: the PlaceOS URL that SSO sends data back to - to log someone in
     -  First set this to the base domain of the application.
@@ -65,10 +65,10 @@ Here is a description of each field:
 
   | Name | Mappings |
   | --- | --- |
-  | email | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` |
-  | first_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` |
-  | last_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname` |
-  | login_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/objectidentifier` |
+  | `email` | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` |
+  | `first_name` | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` |
+  | `last_name` | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname` |
+  | `login_name` | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/objectidentifier` |
 
 Once you click save, it will generate an authentication ID.
 You can find it in the `/saml_auths` response on the Authentication tab.
@@ -105,7 +105,7 @@ From the above steps you will need:
 - The **Login URL** which is the homepage of the app
 - The **Metadata URL** (optional)  
 
-This XML file contains the above information and can be fed into to some configuration dashboards (like ADFS).
+This XML file contains the above information and can be fed into to some configuration dashboards (like AD FS).
 
 This process will vary by provider, see the below guides for common options:
 
@@ -172,3 +172,4 @@ Look for the text **"Callback phase initiated"** and the SAML response data is n
 
 
 *[AD FS]: Active Directory Federation Services
+*[OKTA]: OKTA Authentication Service

--- a/how-to/authentication/configure-saml.md
+++ b/how-to/authentication/configure-saml.md
@@ -172,4 +172,5 @@ Look for the text **"Callback phase initiated"** and the SAML response data is n
 
 
 *[AD FS]: Active Directory Federation Services
-*[OKTA]: OKTA Authentication Service
+*[OKTA]: `OKTA` Authentication Service
+*[IDP]: Identity Provider

--- a/how-to/authentication/configure-saml.md
+++ b/how-to/authentication/configure-saml.md
@@ -68,7 +68,7 @@ Here is a description of each field:
   | email | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` |
   | first_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` |
   | last_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname` |
-  | login_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress` |
+  | login_name | `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/objectidentifier` |
 
 Once you click save, it will generate an authentication ID.
 You can find it in the `/saml_auths` response on the Authentication tab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2567,43 +2567,51 @@
       "dev": true
     },
     "@textlint/ast-tester": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-12.0.0.tgz",
-      "integrity": "sha512-mcAqaOJnAhay8QtDC/na5S72XPxmqGCntOwcLwuSjEmPGAIuLC3GsumLQo4nWSQ2LGnWd6CwLDZT4eBlRWetNA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-tester/-/ast-tester-12.0.2.tgz",
+      "integrity": "sha512-kHta27+SJC0YxEyEdlNux6m2JepX920gc5x98lVBVYK6Wq6cAF67EEGl1o9ynqroIHEc3wTSEDOFwxXpnlfsNA==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0",
-        "debug": "^4.3.1"
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@textlint/ast-traverse": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-12.0.0.tgz",
-      "integrity": "sha512-Mu0il8qWS9YkzVAqwmrTd+ga5S0LJVWOGjE6d9yADf5xObUDFk4g8ITlfEOiicpX5bTUxT4e1bORxPveCJ8iKQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-traverse/-/ast-traverse-12.0.2.tgz",
+      "integrity": "sha512-OrbGnwtqNAsX7jVSRKecc1Lp2tg54ntnTuvOHkYrZrlC72Hk7+7V/UFQBmFNQCe0cH6Tjb5FFFcgp6f8gM+ehw==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0"
       }
     },
     "@textlint/feature-flag": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-12.0.0.tgz",
-      "integrity": "sha512-xgK6tsf1Gg6xn8/X0HN4LXzSkJYgmByAvzItUPlI0dzvA4HhhT4gkBeshDCuXsHLc970nYgzy1TYHpyscu7PTw==",
-      "dev": true,
-      "requires": {
-        "map-like": "^2.0.0"
-      }
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/feature-flag/-/feature-flag-12.0.2.tgz",
+      "integrity": "sha512-yNq5uErjFrVq1gghg3A8D77+E36wLXRws5LwSsoRC4LVPIGR+LYZ9BlkoyNTas8dOzGwTs6XZIcWCIWXy77M8Q==",
+      "dev": true
     },
     "@textlint/fixer-formatter": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-12.0.0.tgz",
-      "integrity": "sha512-y2PWue8PANhSF9cXwksxmjDs/n9exOq4daNMhN7VvJk9yrXL+nSuAoyDXjyp09gX4Nfwa/xsOrQRTDVRbizgcw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/fixer-formatter/-/fixer-formatter-12.0.2.tgz",
+      "integrity": "sha512-ii49bDLVcgnnxmnaZFX0rDFEIGH3o6DGKnr76cfqy6+DWkGQlhBPyRdbx2bIF65KT+7nAMU0JjfEK+n/WIYFTA==",
       "dev": true,
       "requires": {
-        "@textlint/module-interop": "^12.0.0",
-        "@textlint/types": "^12.0.0",
+        "@textlint/module-interop": "^12.0.2",
+        "@textlint/types": "^12.0.2",
         "chalk": "^1.1.3",
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "diff": "^4.0.2",
         "is-file": "^1.0.0",
         "string-width": "^1.0.2",
@@ -2646,6 +2654,15 @@
                 "ansi-regex": "^2.0.0"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "is-fullwidth-code-point": {
@@ -2694,43 +2711,53 @@
       "dev": true
     },
     "@textlint/kernel": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-12.0.0.tgz",
-      "integrity": "sha512-8UXHKhSAgn1aexPjyQE1CRVivCfSz+aFuNrktT9+JOMM3XsSd4JFcMKDhPA1utiiRR+4yDVH5be38vuuJOG9cQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/kernel/-/kernel-12.0.2.tgz",
+      "integrity": "sha512-IVWC5xyHj58X3/sUXAOndOPMQMkvGaXXPCtLITm8rSwKRc4D/qF2hhwAisOu8XImIwBGzvhFlq+IM7cUW1qDtA==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0",
-        "@textlint/ast-tester": "^12.0.0",
-        "@textlint/ast-traverse": "^12.0.0",
-        "@textlint/feature-flag": "^12.0.0",
-        "@textlint/source-code-fixer": "^12.0.0",
-        "@textlint/types": "^12.0.0",
-        "@textlint/utils": "^12.0.0",
-        "debug": "^4.3.1",
+        "@textlint/ast-tester": "^12.0.2",
+        "@textlint/ast-traverse": "^12.0.2",
+        "@textlint/feature-flag": "^12.0.2",
+        "@textlint/source-code-fixer": "^12.0.2",
+        "@textlint/types": "^12.0.2",
+        "@textlint/utils": "^12.0.2",
+        "debug": "^4.3.2",
         "deep-equal": "^1.1.1",
-        "map-like": "^2.0.0",
         "structured-source": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@textlint/linter-formatter": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-12.0.0.tgz",
-      "integrity": "sha512-jRRZluLCBXcP8VlA90N8DJOPy890j7rVOVSuyyFn0ypuUK88X2qH9XoEd9yYbo/HmH9ky2h+TeA8CJtOAIjU2g==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-12.0.2.tgz",
+      "integrity": "sha512-xRTkLmMUnxW5Y6UXsIc9iLo8hyj5toYXVA/u5ABO4t3QObgtUllWi9W2eauZeY19pLTXweBHYxqG/tl3jTCpJQ==",
       "dev": true,
       "requires": {
         "@azu/format-text": "^1.0.1",
         "@azu/style-format": "^1.0.0",
-        "@textlint/module-interop": "^12.0.0",
-        "@textlint/types": "^12.0.0",
+        "@textlint/module-interop": "^12.0.2",
+        "@textlint/types": "^12.0.2",
         "chalk": "^1.1.3",
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "is-file": "^1.0.0",
         "js-yaml": "^3.14.1",
         "optionator": "^0.9.1",
         "pluralize": "^2.0.0",
         "string-width": "^1.0.2",
         "strip-ansi": "^6.0.0",
-        "table": "^3.8.3",
+        "table": "^6.7.1",
         "text-table": "^0.2.0",
         "try-resolve": "^1.0.1",
         "xml-escape": "^1.1.0"
@@ -2770,6 +2797,15 @@
                 "ansi-regex": "^2.0.0"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "is-fullwidth-code-point": {
@@ -2812,13 +2848,13 @@
       }
     },
     "@textlint/markdown-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.0.0.tgz",
-      "integrity": "sha512-XaiuePJVDGVIwdjIiITdbdRXZDFnAFY/so3Rb8qAId/Qq9fKPUvgefMkdIG73wUC7LzhrAzH6/CuEO+f77HR5g==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.0.2.tgz",
+      "integrity": "sha512-xAJ4U/fOL7FoX4bYeYRCsSIeTxFqzKd944AsVxAYrz2ZfKH0TtBSNDDtN22uBEXOrSCCR12Z7QuMcp+URyYWlw==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0",
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "remark-footnotes": "^3.0.0",
         "remark-frontmatter": "^3.0.0",
         "remark-gfm": "^1.0.0",
@@ -2827,6 +2863,15 @@
         "unified": "^9.2.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "is-buffer": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -2853,9 +2898,9 @@
           }
         },
         "unified": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
-          "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+          "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
           "dev": true,
           "requires": {
             "bail": "^1.0.0",
@@ -2869,9 +2914,9 @@
       }
     },
     "@textlint/module-interop": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.0.0.tgz",
-      "integrity": "sha512-WSuwd3pd2xYDCYqpA6NE8FwMZS4WJ2gZmsSCXBpOh3qJ/pHbmrfEaiwOpGQJA4RfXVp8Fy5KfaAQJIr+wox98A==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-12.0.2.tgz",
+      "integrity": "sha512-jnFx7B7Q/au49n5Kt/ttPhecvnJGj7643KzPxRNXy422nmafi1EfOZDMGkNEJhlVsQ9WzAnliTTXTFTrBhtVYA==",
       "dev": true
     },
     "@textlint/regexp-string-matcher": {
@@ -2889,55 +2934,66 @@
       }
     },
     "@textlint/source-code-fixer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-12.0.0.tgz",
-      "integrity": "sha512-+XMJ7unzezEqKh8euWIw1QUprvv7IJzOfV0UPVbkThX2d3ZOzBmK+AzlYbqzCwZ1jkV0QYaRqaptBE+iaaQjNg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/source-code-fixer/-/source-code-fixer-12.0.2.tgz",
+      "integrity": "sha512-lWNndH7Z+KGo8NhM4e3I5fR0SfZeS25AW7MRQGsKbxHL8NSi6KmCXVK8unEls82+DKXW4VdjTTgVYTTOVGa3BA==",
       "dev": true,
       "requires": {
-        "@textlint/types": "^12.0.0",
-        "debug": "^4.3.1"
+        "@textlint/types": "^12.0.2",
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "@textlint/text-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-12.0.0.tgz",
-      "integrity": "sha512-j73hF6BiwdZurNdzHfOtP5j3v+nTWaTP7RtJf5wpfQBigT4RA+EqmKxUd/OpO+gt/Xy1NkpceLFNllZGRLEvkw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/text-to-ast/-/text-to-ast-12.0.2.tgz",
+      "integrity": "sha512-vgB4k4CpY59XVrcvWLyFkCoMIVpiUheuy2FC1+Qb44hmoEYT26uglX7SEkBRTQvlzsjChgryzA2PFf2c1wkL0Q==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0"
       }
     },
     "@textlint/textlint-plugin-markdown": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-12.0.0.tgz",
-      "integrity": "sha512-eo9deECYMkytoiJUqDxEwzugL8sLcCFUbeCpzV5IuIRwQBh85Hds3lp/mtW1B3Q/BxcSa08im2HAa9uRdcoe4Q==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-markdown/-/textlint-plugin-markdown-12.0.2.tgz",
+      "integrity": "sha512-3qizGxt/cz0foqmUuqpk0hnQzXdDehG0CBrzUINJVa7btpDn8bD9fRYn88OdmGLtejVJR/pUDOOZk3RYYEVmlQ==",
       "dev": true,
       "requires": {
-        "@textlint/markdown-to-ast": "^12.0.0"
+        "@textlint/markdown-to-ast": "^12.0.2"
       }
     },
     "@textlint/textlint-plugin-text": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-12.0.0.tgz",
-      "integrity": "sha512-brtexdqu7yvFLstYvVlotMZz5T7SwKfnFnV9Sm+uhg/d3Ddea9exzpiWWcXfRAhfOBd12mmEGM6gwAuSwzrhqg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/textlint-plugin-text/-/textlint-plugin-text-12.0.2.tgz",
+      "integrity": "sha512-giCTwrioT6bYlOZ+xf/c9ML1GYitQVrtToHzWI6AAs8szg+Q5+h3KCG921sDEGgZfqnljuBaYcHJsW/iNG1+UA==",
       "dev": true,
       "requires": {
-        "@textlint/text-to-ast": "^12.0.0"
+        "@textlint/text-to-ast": "^12.0.2"
       }
     },
     "@textlint/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-3sB22cGtN9nPViDrW7FJxWkDrpGtyJbvNsvZqzX83HJbAiOmzzeHDkRRLvz9tax76lcdjlNk+2rHY3iSnjhEag==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-12.0.2.tgz",
+      "integrity": "sha512-w5aWSCd1sot1waiYw8KnmJNY1q+k9LDoaA6xjGbBuVBGJl0TLXIZoOP8HYFUcKFfJRpqGGob1geTHiyFdnyS0w==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0"
       }
     },
     "@textlint/utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-12.0.0.tgz",
-      "integrity": "sha512-bnIr17iouc4MtVR+r7v8mBasNn3ZsQpfTLTi4RelrZJdICHMBUMOWRX70cVRV/xJck/nfY9igt325qI0y2ELoQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-12.0.2.tgz",
+      "integrity": "sha512-IYmibhDMWd8EmRvk8ii9AA/ecrZk5Wj5NNcKuB78+ae2PIVI1zWzQoieSvQyX7DLPRVH4S22RORiEpruRcDzng==",
       "dev": true
     },
     "@trysound/sax": {
@@ -4597,12 +4653,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
@@ -8615,15 +8665,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8652,12 +8693,6 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
     },
     "jsx-ast-utils": {
       "version": "3.2.0",
@@ -9154,12 +9189,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "map-like": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-like/-/map-like-2.0.0.tgz",
-      "integrity": "sha1-lEltSa0zPA3DI0snrbvR6FNZU7Q=",
       "dev": true
     },
     "map-obj": {
@@ -13109,10 +13138,47 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
+      }
     },
     "sliced": {
       "version": "1.0.1",
@@ -13846,100 +13912,35 @@
       }
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
-        "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         }
       }
@@ -14009,30 +14010,29 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "textlint": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/textlint/-/textlint-12.0.0.tgz",
-      "integrity": "sha512-hpXezTFR/BxNzc0iJqwspAuHYrCWF/nF7mBS9OGzgBJx5FfS1xfsAIityV65Ffcr+nxCExzTQqRHR6qSWOZmbg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/textlint/-/textlint-12.0.2.tgz",
+      "integrity": "sha512-pg453CN2xtLoqss9YVSKkEFJtJ1AB/9SWTxl11fgdqFPCOK2W/320CJRqSxo5bJFpIn5+6bjqkuPHS0cZWLPvg==",
       "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^12.0.0",
-        "@textlint/ast-traverse": "^12.0.0",
-        "@textlint/feature-flag": "^12.0.0",
-        "@textlint/fixer-formatter": "^12.0.0",
-        "@textlint/kernel": "^12.0.0",
-        "@textlint/linter-formatter": "^12.0.0",
-        "@textlint/module-interop": "^12.0.0",
-        "@textlint/textlint-plugin-markdown": "^12.0.0",
-        "@textlint/textlint-plugin-text": "^12.0.0",
-        "@textlint/types": "^12.0.0",
-        "@textlint/utils": "^12.0.0",
-        "debug": "^4.3.1",
+        "@textlint/ast-traverse": "^12.0.2",
+        "@textlint/feature-flag": "^12.0.2",
+        "@textlint/fixer-formatter": "^12.0.2",
+        "@textlint/kernel": "^12.0.2",
+        "@textlint/linter-formatter": "^12.0.2",
+        "@textlint/module-interop": "^12.0.2",
+        "@textlint/textlint-plugin-markdown": "^12.0.2",
+        "@textlint/textlint-plugin-text": "^12.0.2",
+        "@textlint/types": "^12.0.2",
+        "@textlint/utils": "^12.0.2",
+        "debug": "^4.3.2",
         "deep-equal": "^1.1.1",
         "file-entry-cache": "^5.0.1",
         "get-stdin": "^5.0.1",
         "glob": "^7.1.7",
         "is-file": "^1.0.0",
         "log-symbols": "^1.0.2",
-        "map-like": "^2.0.0",
         "md5": "^2.3.0",
         "mkdirp": "^0.5.0",
         "optionator": "^0.9.1",
@@ -14043,6 +14043,17 @@
         "structured-source": "^3.0.2",
         "try-resolve": "^1.0.1",
         "unique-concat": "^0.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "textlint-filter-rule-allowlist": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "dictionary-en": "^3.1.0",
     "placeos-docs-site": "github:placeos/docs-site",
-    "textlint": "^12.0.0",
+    "textlint": "^12.0.2",
     "textlint-filter-rule-allowlist": "^3.0.0",
     "textlint-rule-alex": "^3.0.0",
     "textlint-rule-common-misspellings": "^1.0.1",


### PR DESCRIPTION
docs(auth/saml): map login_name to objectidentifier not emailaddress
because email address is mutable

ms docs state that objectidentifier is the best field to use for uniquely identifying users (better than UPN).

Side note: In fact staff-api should also be changed to starts using user.objectidentifier instead of user.email or user.userprincipalname. This will prevent issues when users change email and allow support for azure b2b guest users.